### PR TITLE
Drop version requirement down a few notches

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -78,7 +78,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
   "pdk-version": "1.4.1",


### PR DESCRIPTION
Since this type is not bundled with puppet-agent we should loosen the version requirements. People will be adding it to their module's dependencies, and will expect this module to claim support for the Puppet version they're using.

This module appears to [already be tested on Puppet 4.10](https://github.com/puppetlabs/puppetlabs-maillist_core/blob/master/.travis.yml#L32).